### PR TITLE
Modify search term

### DIFF
--- a/src/components/SearchModal/filtering.ts
+++ b/src/components/SearchModal/filtering.ts
@@ -1,6 +1,12 @@
 import { isAddress } from '../../utils'
 import { Token } from '@wanswap/sdk'
 
+const prepareTermForSearch = (term: string) =>
+  term
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(s => s.length > 0)
+
 export function filterTokens(tokens: Token[], search: string): Token[] {
   if (search.length === 0) return tokens
 
@@ -10,22 +16,20 @@ export function filterTokens(tokens: Token[], search: string): Token[] {
     return tokens.filter(token => token.address === searchingAddress)
   }
 
-  const lowerSearchParts = search
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(s => s.length > 0)
+  //will remove comments before merge, just wondering what this is meant to do?
+  //It doesn't seem like you can write whitespace characters into the search bar so the split doesn't make much sense to me
+  const lowerSearchParts = prepareTermForSearch(search)
 
   if (lowerSearchParts.length === 0) {
     return tokens
   }
 
   const matchesSearch = (s: string): boolean => {
-    const sParts = s
-      .toLowerCase()
-      .split(/\s+/)
-      .filter(s => s.length > 0)
+    //likewise, I dont think you're symbols or names will have whitespace characters in them
+    const sParts = prepareTermForSearch(s)
 
-    return lowerSearchParts.every(p => p.length === 0 || sParts.some(sp => sp.startsWith(p) || sp.endsWith(p)))
+    // return lowerSearchParts.every(p => p.length === 0 || sParts.some(sp => sp.startsWith(p) || sp.endsWith(p)))
+    return lowerSearchParts.every(p => p.length === 0 || sParts.some(sp => sp.includes(p)))
   }
 
   return tokens.filter(token => {

--- a/src/components/SearchModal/filtering.ts
+++ b/src/components/SearchModal/filtering.ts
@@ -1,6 +1,12 @@
 import { isAddress } from '../../utils'
 import { Token } from '@wanswap/sdk'
 
+const prepareTermForSearch = (term: string) =>
+  term
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(s => s.length > 0)
+
 export function filterTokens(tokens: Token[], search: string): Token[] {
   if (search.length === 0) return tokens
 
@@ -10,20 +16,14 @@ export function filterTokens(tokens: Token[], search: string): Token[] {
     return tokens.filter(token => token.address === searchingAddress)
   }
 
-  const lowerSearchParts = search
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(s => s.length > 0)
+  const lowerSearchParts = prepareTermForSearch(search)
 
   if (lowerSearchParts.length === 0) {
     return tokens
   }
 
   const matchesSearch = (s: string): boolean => {
-    const sParts = s
-      .toLowerCase()
-      .split(/\s+/)
-      .filter(s => s.length > 0)
+    const sParts = prepareTermForSearch(s)
 
     return lowerSearchParts.every(p => p.length === 0 || sParts.some(sp => sp.includes(p)))
   }

--- a/src/components/SearchModal/filtering.ts
+++ b/src/components/SearchModal/filtering.ts
@@ -28,7 +28,6 @@ export function filterTokens(tokens: Token[], search: string): Token[] {
     //likewise, I dont think you're symbols or names will have whitespace characters in them
     const sParts = prepareTermForSearch(s)
 
-    // return lowerSearchParts.every(p => p.length === 0 || sParts.some(sp => sp.startsWith(p) || sp.endsWith(p)))
     return lowerSearchParts.every(p => p.length === 0 || sParts.some(sp => sp.includes(p)))
   }
 

--- a/src/components/SearchModal/filtering.ts
+++ b/src/components/SearchModal/filtering.ts
@@ -1,12 +1,6 @@
 import { isAddress } from '../../utils'
 import { Token } from '@wanswap/sdk'
 
-const prepareTermForSearch = (term: string) =>
-  term
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(s => s.length > 0)
-
 export function filterTokens(tokens: Token[], search: string): Token[] {
   if (search.length === 0) return tokens
 
@@ -16,17 +10,20 @@ export function filterTokens(tokens: Token[], search: string): Token[] {
     return tokens.filter(token => token.address === searchingAddress)
   }
 
-  //will remove comments before merge, just wondering what this is meant to do?
-  //It doesn't seem like you can write whitespace characters into the search bar so the split doesn't make much sense to me
-  const lowerSearchParts = prepareTermForSearch(search)
+  const lowerSearchParts = search
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(s => s.length > 0)
 
   if (lowerSearchParts.length === 0) {
     return tokens
   }
 
   const matchesSearch = (s: string): boolean => {
-    //likewise, I dont think you're symbols or names will have whitespace characters in them
-    const sParts = prepareTermForSearch(s)
+    const sParts = s
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(s => s.length > 0)
 
     return lowerSearchParts.every(p => p.length === 0 || sParts.some(sp => sp.includes(p)))
   }


### PR DESCRIPTION
Simple proposal to match part of the search term instead of just the begining or end when searching for tokens. 
A similar example is the search in pancakeswap. 

As most of the wrapped tokens have 'wan' preceding them, the user has to write these 3 letters each time before any meaningful search occurs. Partial search allows to filter away the unnecessary tokens faster. 
A great example is just writing 'v' and wanVibe will be selectable, as the letter 'v' is only available in this one token. 

I also separated a function into a reusable one, though I'm not sure if it is really necessary as whitespace characters  aren't enterable into the search bar, and even if they are then there just won't be any results. 

I also considered adding highlighting so the filtered results would show where the match was found but 
a) it would alter too much of your code for little benefit, especially since the token list isn't too long,
b) other dex's manage without it.

To sum up, the only real change is in line 31, the rest can be removed if it is not in accordance with your style. 