### PR TITLE
Add a warning popup when user is low on WAN and might run out for gas…

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -98,7 +98,6 @@
   "selectAToken": "Select a token",
   "enterARecipient": "Enter a recipient",
   "invalidRecipient2": "Invalid Recipient",
-
   "from": "From",
   "fromEstimated": "From (estimated)",
   "addRecipient": "+ Add a send (optional)",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -86,7 +86,7 @@
   "brokenToken": "The selected token is not compatible with Uniswap V1. Adding liquidity will result in locked funds.",
   "toleranceExplanation": "Lowering this limit decreases your risk of frontrunning. However, this makes more likely that your transaction will fail due to normal price movements.",
   "tokenSearchPlaceholder": "Search name or paste address",
-  
+
   "miningPool": "Farming",
   "hive": "Hive",
   "vote": "Vote",
@@ -134,6 +134,7 @@
   "transactionSubmitted": "Transaction Submitted",
   "close": "Close",
   "viewOn": "View on wanscan.org",
+  "lowWanAmountWarning": "You are running low on WAN for fees. Consider topping up",
   "liquidityProviderRewards": "Liquidity provider rewards",
   "readMoreAboutProvidingLiquidity":"Read more about providing liquidity",
   "liquidityHelper":"Liquidity providers earn a 0.3% fee on all trades proportional to their share of the pool. Fees are added to the pool, accrue in real time and can be claimed by withdrawing your liquidity. ",

--- a/src/components/Popups/PopupItem.tsx
+++ b/src/components/Popups/PopupItem.tsx
@@ -7,6 +7,7 @@ import { PopupContent } from '../../state/application/actions'
 import { useRemovePopup } from '../../state/application/hooks'
 import ListUpdatePopup from './ListUpdatePopup'
 import TransactionPopup from './TransactionPopup'
+import WarningMessagePopup from './WarningMessagePopup'
 
 export const StyledClose = styled(X)`
   position: absolute;
@@ -82,6 +83,8 @@ export default function PopupItem({
       listUpdate: { listUrl, oldList, newList, auto }
     } = content
     popupContent = <ListUpdatePopup popKey={popKey} listUrl={listUrl} oldList={oldList} newList={newList} auto={auto} />
+  } else if ('lowWanForFees' in content) {
+    popupContent = <WarningMessagePopup message={'lowWanAmountWarning'} />
   }
 
   const faderStyle = useSpring({

--- a/src/components/Popups/WarningMessagePopup.tsx
+++ b/src/components/Popups/WarningMessagePopup.tsx
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react'
+import { AlertCircle } from 'react-feather'
+import { useTranslation } from 'react-i18next'
+import styled, { ThemeContext } from 'styled-components'
+import { TYPE } from '../../theme'
+import { AutoColumn } from '../Column'
+import { AutoRow } from '../Row'
+
+const RowNoFlex = styled(AutoRow)`
+  flex-wrap: nowrap;
+`
+
+export default function WarningMessagePopup({ message }: { message: string }) {
+  const theme = useContext(ThemeContext)
+  const { t } = useTranslation()
+
+  return (
+    <RowNoFlex>
+      <div style={{ paddingRight: 16 }}>
+        <AlertCircle color={theme.red1} size={24} />
+      </div>
+      <AutoColumn gap="8px">
+        <TYPE.body fontWeight={500}>{t(message)}</TYPE.body>
+      </AutoColumn>
+    </RowNoFlex>
+  )
+}

--- a/src/state/application/actions.ts
+++ b/src/state/application/actions.ts
@@ -17,6 +17,9 @@ export type PopupContent =
         auto: boolean
       }
     }
+  | {
+      lowWanForFees: boolean
+    }
 
 export enum ApplicationModal {
   WALLET,


### PR DESCRIPTION
This PR aims to add a warning popup (similar to a failed transaction) when the user is running low on WAN in his/her wallet. 

The hope is that the user will see it and top up the amount of WAN they have in order to have enough for future transactions. 

Several times people on zookeeper have had issues which were the result of them lacking enough WAN for transactions - I suspect this sometimes happens on wanswap. A similar feature could be added to zookeeper. 

Currently I found the average transaction cost of 0.042 WAN, which seems high to me [source](https://wikicryptocoins.com/currency/Wanchain#:~:text=At%20Wanchain%2C%20the%20average%20transaction,such%20as%20Bitcoin%20and%20Ethereum). Will gladly change the value if a better source is found. Better yet, if this value was not static and could be pulled form somewhere. 

I have set the amount to be enough for 5 transactions - this can be discussed but I think its enough for a user to actually notice the popup and do something about it. 

I have only added an english translation. I considered adding other languages using google translate but saw that they also lack translation keys (such as the 'viewOn' key). Let me know and I can add any other languages you see as needed if you provide translations (or I can use google translate).